### PR TITLE
Fix image reference for the reloader

### DIFF
--- a/helm/promviz/values.yaml
+++ b/helm/promviz/values.yaml
@@ -41,7 +41,7 @@ promviz:
 ## Configurations for reloader container
 reloader:
   image:
-    repository: nghialv2607/config-reloader-k8s
+    repository: nghialv2607/k8s-config-reloader
     tag: v0.1.0
     pullPolicy: IfNotPresent
   resources:


### PR DESCRIPTION
The image referenced doesn't exist, fixed to point at the correct one in dockerhub